### PR TITLE
Add bbPress settings to the Genesis Theme Settings customizer panel

### DIFF
--- a/bbpress-genesis-extend-settings.php
+++ b/bbpress-genesis-extend-settings.php
@@ -3,26 +3,80 @@
  * Main bbPress Genesis Extend settings class
  *
  * Registers a few bbPress-Genesis specific options on the Genesis Setting page.
- * 
+ *
  * @package  bbPressGenesisExtend
  * @since    0.8.0
  */
 class bbpge_settings {
-	
+
 	/**
 	 * construct ALL THE THINGS
 	 *
 	 * @since 0.8.0
 	 */
-	function __construct() {	
+	function __construct() {
+		// Filter settings config
+		add_filter( 'genesis_customizer_theme_settings_config', array( $this, 'customizer_settings' ) );
+
 		// Option default values
 		add_filter( 'genesis_theme_settings_defaults',  array( $this, 'options_defaults'      ) );
-		
+
 		// Saniztize options
 		add_action( 'genesis_settings_sanitizer_init',  array( $this, 'sanitization_filters'  ) );
 
 		// Register settings
 		add_action( 'genesis_theme_settings_metaboxes', array( $this, 'register_settings_box' ) );
+	}
+
+	/**
+	 * Filters the customizer config that builds the theme settings in the customizer.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param array $config The config array to be filtered.
+	 * @return array The filtered config array.
+	 */
+	public function customizer_settings( array $config ) {
+		$config['genesis']['sections']['bbpress'] = array(
+			'title'    => __( 'bbPress', 'bbpress-genesis-extend' ),
+			'panel'    => 'genesis',
+			'controls' => array(
+				'bbp_forum_layout'  => array(
+					'label'    => __( 'Forum Layout', 'bbpress-genesis-extend' ),
+					'section'  => 'bbpress',
+					'type'     => 'select',
+					'choices'  => array_merge(
+						array(
+							'genesis-default' => __( 'Genesis Default', 'bbpress-genesis-extend' ),
+						),
+						genesis_get_layouts_for_customizer()
+					),
+					'settings' => array(
+						'default' => 'genesis-default',
+					),
+				),
+				'bbp_forum_sidebar' => array(
+					'label'       => __( 'Register Sidebar?', 'bbpress-genesis-extend' ),
+					'description' => __( 'Register a forum specific sidebar that will be used on all forum pages', 'bbpress-genesis-extend' ),
+					'section'     => 'bbpress',
+					'type'        => 'checkbox',
+					'settings'    => array(
+						'default' => 0,
+					),
+				),
+				'bbp_forum_desc'    => array(
+					'label'       => __( 'Remove forum and topic descriptions?', 'bbpress-genesis-extend' ),
+					'description' => __( 'E.g. "This forum contains [&hellip;]" notices.', 'bbpress-genesis-extend' ),
+					'section'     => 'bbpress',
+					'type'        => 'checkbox',
+					'settings'    => array(
+						'default' => 0,
+					),
+				),
+			),
+		);
+
+		return $config;
 	}
 
 	/**
@@ -50,7 +104,7 @@ class bbpge_settings {
 
 		// bbp_forum_sidebar
 		genesis_add_option_filter( 'one_zero', GENESIS_SETTINGS_FIELD, array( 'bbp_forum_sidebar' ) );
-		
+
 		// bbp_forum_desc
 		genesis_add_option_filter( 'one_zero', GENESIS_SETTINGS_FIELD, array( 'bbp_forum_desc'    ) );
 	}
@@ -70,14 +124,14 @@ class bbpge_settings {
 	 *
 	 * @since 0.8.0
 	 */
-	function settings_box() {	
+	function settings_box() {
 		?>
 		<p>
 			<label for="bbp_forum_layout"><?php _e( 'Forum Layout: ', 'bbpress-genesis-extend' ); ?></label>
 			<select name="<?php echo GENESIS_SETTINGS_FIELD; ?>[bbp_forum_layout]" id="bbp_forum_layout">
-				<option value="genesis-default" <?php selected( genesis_get_option( 'bbp_forum_layout' ), 'genesis-default' ); ?>><?php _e( 'Genesis default', 'bbpress-genesis-extend' ); ?></option> 
+				<option value="genesis-default" <?php selected( genesis_get_option( 'bbp_forum_layout' ), 'genesis-default' ); ?>><?php _e( 'Genesis default', 'bbpress-genesis-extend' ); ?></option>
 				<?php
-				foreach ( genesis_get_layouts() as $id => $data ) {	
+				foreach ( genesis_get_layouts() as $id => $data ) {
 					echo '<option value="' . esc_attr( $id ) . '" ' . selected( genesis_get_option( 'bbp_forum_layout' ), esc_attr( $id ) ) . '>' . esc_attr( $data['label'] ) . '</option>';
 				}
 				?>

--- a/init.php
+++ b/init.php
@@ -3,22 +3,22 @@
  * Plugin Name: bbPress Genesis Extend
  * Plugin URI:  http://wordpress.org/extend/plugins/bbpress-genesis-extend/
  * Description: Provides basic compaitibility between bbPress and the <a href="http://jaredatchison.com/go/genesis/">Genesis Framework</a>.
- * Version:     1.1.1
+ * Version:     1.2.0
  * Author:      Jared Atchison
- * Author URI:  http://www.jaredatchison.com 
+ * Author URI:  http://www.jaredatchison.com
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * @author     Jared Atchison
- * @version    1.1.1
+ * @version    1.2.0
  * @package    bbPressGenesisExtend
  * @copyright  Copyright (c) 2012, Jared Atchison
  * @link       http://jaredatchison.com
@@ -45,7 +45,7 @@ class bbpge_init {
 
 		add_action( 'genesis_init', array( $this, 'genesis_check' ) );
 	}
-	
+
 	/**
 	 * Check to see if  a Genesis child theme is in place.
 	 *
@@ -83,7 +83,7 @@ class bbpge_init {
 	function pe_init() {
 		load_plugin_textdomain( 'bbpress-genesis-extend', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
 	}
-	
+
 }
 
 new bbpge_init();

--- a/readme.txt
+++ b/readme.txt
@@ -1,18 +1,18 @@
 === bbPress Genesis Extend ===
-Contributors: jaredatch
+Contributors: jaredatch, nathanrice
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=AD8KTWTTDX9JL
 Tags: bbpress, genesis
 Requires at least: 4.0.0
 Tested up to: 4.0.0
 Stable tag: trunk
- 
+
 Provides basic compatibility with bbPress and the Genesis Framework with a few extra goodies.
 
 == Description ==
 
 bbPress and the Genesis Framework are both fantastic additions to any WordPress site. However, depending on your setup they don't always play nice right away.
 
-bbPress Genesis Extend does some behind-the-scenes tweaks and fixes to make bbPress/Genesis integration as quick and painless as possible. 
+bbPress Genesis Extend does some behind-the-scenes tweaks and fixes to make bbPress/Genesis integration as quick and painless as possible.
 
 Additionally, this plugin also:
 
@@ -47,9 +47,12 @@ Specifically, font sizes often need to be adjusted so bbPress "blends" with your
 
 == Screenshots ==
 
-1. Options on the Genesis Settings page. 
+1. Options on the Genesis Settings page.
 
 == Changelog ==
+
+= 1.2.0 =
+* Add bbPress settings to Genesis customizer panel.
 
 = 1.1.1
 * Fixed issue with Genesis profile fields on front end, props @dreamwhisper


### PR DESCRIPTION
Genesis no longer uses a settings page, but has switched over to the customizer for its theme settings.

The bbPress settings were added to the standard settings page in Genesis, but since that is now gone, settings are unavailable for users.

This plugin should, in addition to adding the controls to the theme settings page for older versions of Genesis, add controls to the theme settings customizer panel.

This also tags 1.2.0 and addes change to the changelog in `readme.txt`.